### PR TITLE
Don't reset frequency and availability on reauth

### DIFF
--- a/site.rb
+++ b/site.rb
@@ -69,8 +69,8 @@ end
     u.name = env["omniauth.auth"]["info"]["name"]
     u.image = env["omniauth.auth"]["info"]["image"]
     u.email = env["omniauth.auth"]["info"]["email"]
-    u.frequency = 0
-    u.available = false
+    u.frequency ||= 0
+    u.available ||= false
     u.save
 
     redirect "/"


### PR DESCRIPTION
Currently meet will reset an RCer's availability and frequency whenever they reauth with RC.
This change should prevent that if the availability and frequency are already set.
